### PR TITLE
:sparkles: 添加函数 `GetClass`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ add_library(IL2CppReflector STATIC
         src/method.cpp
         src/struct.cpp
         src/type.cpp
-        src/property.cpp)
+        src/property.cpp
+        src/tool.cpp
+)
 
 target_include_directories(IL2CppReflector
         PUBLIC

--- a/includes/IL2CppReflector/class.hpp
+++ b/includes/IL2CppReflector/class.hpp
@@ -96,6 +96,13 @@ namespace IL2CppReflector {
 
         [[nodiscard]] void* GetIl2cppClass() const;
     };
+    /**
+     * 创建 IL2CppReflector::Class
+     * @param ImageName Image 名称
+     * @param FullName 类的完整名称(命名空间 + 类名)
+     * @return
+     */
+    IL2CppReflector::Class GetClass(const std::string &ImageName, const std::string &FullName);
 
     void* CreateTypeArrayFromVector(const std::vector<void*>& typeObjects);
 }

--- a/includes/IL2CppReflector/tool.h
+++ b/includes/IL2CppReflector/tool.h
@@ -1,0 +1,19 @@
+/**
+ * @author XGeorge
+ * @date 2025/11/9 13:31:29
+*/
+
+#include <string_view>
+
+namespace tool {
+    /**
+     * @brief 根据最后一次出现的分隔符，将字符串切割成两部分。
+     * 例如: "aa.bb.cc" -> ["aa.bb", "cc"]
+     * @param str 要切割的字符串视图。
+     * @param delimiter 分隔符。
+     * @return 一个包含两部分字符串视图的 std::pair。第一部分是分隔符前的所有内容，第二部分是分隔符后的内容。
+     */
+    std::pair<std::string_view, std::string_view> splitAtLast(const std::string_view &str, char delimiter = '.');
+};
+
+

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -47,6 +47,8 @@
 #include "IL2CppReflector/api/il2cpp.hpp"
 #include "IL2CppReflector/api/vm_runtime_info.hpp"
 
+#include "IL2CppReflector/tool.h"
+
 const void *IL2CppReflector::GetImage(const std::string &Name) {
     const auto domain = Il2CppAPI::il2cpp_domain_get();
     if (!domain) {
@@ -467,6 +469,12 @@ void *IL2CppReflector::Class::CreateNewInstance() const {
         ILRL_LOG_ERROR("Failed to create instance of ", ToString());
     }
     return instance;
+}
+
+IL2CppReflector::Class IL2CppReflector::GetClass(const std::string &ImageName, const std::string &FullName){
+    const auto fullName = tool::splitAtLast(FullName);
+    return IL2CppReflector::Class(std::string(fullName.first), std::string(fullName.second),
+                                  IL2CppReflector::GetImage(ImageName));
 }
 
 void * IL2CppReflector::CreateTypeArrayFromVector(const std::vector<void *> &typeObjects) {

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -1,0 +1,21 @@
+/**
+ * @author XGeorge
+ * @date 2025/11/9 13:31:29
+*/
+
+#include "IL2CppReflector/tool.h"
+
+namespace tool {
+    std::pair<std::string_view, std::string_view> splitAtLast(const std::string_view &str, char delimiter) {
+        auto last_dot = str.rfind(delimiter);
+        if (last_dot != std::string_view::npos) {
+            // 找到了分隔符
+            return {
+                    str.substr(0, last_dot),               // 分隔符之前的部分
+                    str.substr(last_dot + 1)             // 分隔符之后的部分
+            };
+        }
+        // 未找到分隔符，返回一个空的前半部分和完整的原始字符串
+        return {"", str};
+    }
+};


### PR DESCRIPTION
* 在 `IL2CppReflector` 命名空间中新增 `GetClass(const std::string &ImageName, const std::string &FullName)`，方便创建 `IL2CppReflector::Class`
* 支持参数 `const std::string &ImageName, const std::string &FullName`，返回 `IL2CppReflector::Class`
* 简化外部代码创建对象，保持接口一致性